### PR TITLE
Build out structural tests for RTX; add min similarity value test

### DIFF
--- a/features/rtx-tests.feature
+++ b/features/rtx-tests.feature
@@ -13,12 +13,12 @@ Feature: Tests for the RTX reasoning tool
     Scenario: Malaria is associated with sickle cell anemia
         Given the "English" question "What diseases are similar to Malaria?"
         When we send the question to RTX
-        Then the results should include a node with ID "OMIM:603903"
+        Then the results should include node "OMIM:603903 (sickle cell anemia)"
 
     Scenario: Acetaminophen targets PTGS1
         Given the "English" question "What are the drugs that target PTGS1?"
         When we send the question to RTX
-        Then the results should include a node with ID "CHEMBL.COMPOUND:CHEMBL112"
+        Then the results should include node "CHEMBL.COMPOUND:CHEMBL112 (PTGS1)"
 
     Scenario: Fanconi anemia has expected symptoms
         Given the "English" question "What are the symptoms of Fanconi anemia?"
@@ -29,15 +29,15 @@ Feature: Tests for the RTX reasoning tool
             | HP:0001510 | growth delay            |
             | HP:0000252 | microcephaly            |
 
-    Scenario: Phenylalanine hydroxylase is in the phenylketonuria pathway
+    Scenario: PAH is in the phenylketonuria pathway
         Given the "English" question "What proteins are in the phenylketonuria pathway?"
         When we send the question to RTX
-        Then the results should include a node with ID "UniProtKB:P00439"
+        Then the results should include node "UniProtKB:P00439 (PAH)"
 
     Scenario: Naproxen/cyclooxygenase pathway checks
         Given the "English" question "What biological processes involve proteins targeted by naproxen?"
         When we send the question to RTX
-        Then the results should include node "GO:0019371" with similarity value > 0.05
+        Then the results should include node "GO:0019371 (cyclooxygenase pathway)" with similarity value > 0.05
         And the results should contain the following relationships
             | source_id        | name  | edge_type    | target_id  | name                   |
             | UniProtKB:P23219 | PTGS1 | involved_in  | GO:0019371 | cyclooxygenase pathway |

--- a/features/rtx-tests.feature
+++ b/features/rtx-tests.feature
@@ -1,11 +1,6 @@
 Feature: Tests for the RTX reasoning tool
 
-    Scenario: Fanconi anemia gene search produces BRCA2
-        Given the "English" question "What genes are associated with Fanconi anemia?"
-        When we send the question to RTX
-        Then the results should include a node with ID "UniProtKB:P51587"
-
-    Scenario: Fanconi anemia search produces several known associated genes
+    Scenario: Fanconi anemia is associated with expected genes
         Given the "English" question "What genes are associated with Fanconi anemia?"
         When we send the question to RTX
         Then the results should contain the following nodes
@@ -15,26 +10,26 @@ Feature: Tests for the RTX reasoning tool
             | UniProtKB:Q00597 | FANCC  |
             | UniProtKB:O15287 | FANCG  |
 
-    Scenario: Symptoms of fanconi anemia checks
+    Scenario: Malaria is associated with sickle cell anemia
+        Given the "English" question "What diseases are similar to Malaria?"
+        When we send the question to RTX
+        Then the results should include a node with ID "OMIM:603903"
+
+    Scenario: Acetaminophen targets PTGS1
+        Given the "English" question "What are the drugs that target PTGS1?"
+        When we send the question to RTX
+        Then the results should include a node with ID "CHEMBL.COMPOUND:CHEMBL112"
+
+    Scenario: Fanconi anemia has expected symptoms
         Given the "English" question "What are the symptoms of Fanconi anemia?"
         When we send the question to RTX
-        Then the results should contain the following relationships
-            | source_id  | name           | edge_type     | target_id  | name                    |
-            | DOID:13636 | fanconi anemia | has_phenotype | HP:0000978 | bruising susceptibility |
-            | DOID:13636 | fanconi anemia | has_phenotype | HP:0001510 | growth delay            |
-            | DOID:13636 | fanconi anemia | has_phenotype | HP:0000252 | microcephaly            |
+        Then the results should contain the following nodes
+            | id         | name                    |
+            | HP:0000978 | bruising susceptibility |
+            | HP:0001510 | growth delay            |
+            | HP:0000252 | microcephaly            |
 
-    Scenario: PTGS1 physically interacts with acetaminophen
-        Given the machine question
-        """
-        {
-            "query_type_id": "Q3",
-            "terms": {
-                "chemical_substance": "CHEMBL.COMPOUND:CHEMBL112",
-                "rel_type": "physically_interacts_with",
-                "target_label": "protein"
-            }
-        }
-        """
+    Scenario: Phenylalanine hydroxylase is in the phenylketonuria pathway
+        Given the "English" question "What proteins are in the phenylketonuria pathway?"
         When we send the question to RTX
-        Then the results should show that "UniProtKB:P23219" "physically_interacts_with" "CHEMBL.COMPOUND:CHEMBL112"
+        Then the results should include a node with ID "UniProtKB:P00439"

--- a/features/rtx-tests.feature
+++ b/features/rtx-tests.feature
@@ -33,3 +33,12 @@ Feature: Tests for the RTX reasoning tool
         Given the "English" question "What proteins are in the phenylketonuria pathway?"
         When we send the question to RTX
         Then the results should include a node with ID "UniProtKB:P00439"
+
+    Scenario: Naproxen/cyclooxygenase pathway checks
+        Given the "English" question "What biological processes involve proteins targeted by naproxen?"
+        When we send the question to RTX
+        Then the results should include node "GO:0019371" with similarity value > 0.05
+        And the results should contain the following relationships
+            | source_id        | name  | edge_type    | target_id  | name                   |
+            | UniProtKB:P23219 | PTGS1 | involved_in  | GO:0019371 | cyclooxygenase pathway |
+            | UniProtKB:P35354 | PTGS2 | involved_in  | GO:0019371 | cyclooxygenase pathway |

--- a/features/rtx-tests.feature
+++ b/features/rtx-tests.feature
@@ -42,3 +42,16 @@ Feature: Tests for the RTX reasoning tool
             | source_id        | name  | edge_type    | target_id  | name                   |
             | UniProtKB:P23219 | PTGS1 | involved_in  | GO:0019371 | cyclooxygenase pathway |
             | UniProtKB:P35354 | PTGS2 | involved_in  | GO:0019371 | cyclooxygenase pathway |
+
+    Scenario: UROC1 participates in histidine catabolism
+        Given the machine question
+        """
+        {
+            "query_type_id": "Q63",
+            "terms": {
+                "protein": "UniProtKB:Q96N76"
+            }
+        }
+        """
+        When we send the question to RTX
+        Then the results should include node "REACT:R-HSA-6788656 (histidine catabolism)"

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -223,32 +223,45 @@ def step_impl(context, node_id):
     node_found = any(node['id'] == node_id for node in nodes)
     assert node_found
 
+
+@then('the results should include node "{node_id}" with similarity value > {min_expected_value}')
+def step_impl(context, node_id, min_expected_value):
+    results = context.response_json["results"]
+    relevant_result = next((result for result in results if result['row_data'][3] == node_id), None)
+    assert relevant_result is not None
+    similarity_value = relevant_result['row_data'][4]
+    assert similarity_value > min_expected_value
+
+
 @then('the results should contain the following nodes')
 def step_impl(context):
     """
     This step takes in a list of nodes (provided in table format) and checks to see if they are present in the
-    knowledge graph.
+    response knowledge graph.
     """
     response_nodes = context.response_json["knowledge_graph"]["nodes"]
     for row in context.table:
         node_found = any(node['id'] == row['id'] for node in response_nodes)
         assert node_found
 
+
 @then('the results should show that "{source_node}" "{edge_type}" "{target_node}"')
 def step_impl(context, source_node, target_node, edge_type):
     """
-    This step checks for the presence of a particular edge in the knowledge graph.
+    This step checks for the presence of a particular edge in the response knowledge graph.
     """
     edges = context.response_json["knowledge_graph"]["edges"]
-    edge_found = any(edge['source_id'] == source_node and edge['target_id'] == target_node and edge['type'] == edge_type
-                     for edge in edges)
+    edge_found = any(edge['source_id'] == source_node
+                     and edge['target_id'] == target_node
+                     and edge['type'] == edge_type for edge in edges)
     assert edge_found
+
 
 @then('the results should contain the following relationships')
 def step_impl(context):
     """
     This step takes in a list of edges (provided in table format) and checks to see if they are present in the
-    knowledge graph.
+    response knowledge graph.
     """
     response_edges = context.response_json["knowledge_graph"]["edges"]
     for row in context.table:
@@ -256,6 +269,7 @@ def step_impl(context):
                          and edge['target_id'] == row['target_id']
                          and edge['type'] == row['edge_type'] for edge in response_edges)
         assert edge_found
+
 
 @then('the response should have some node with id "{id}" and field "{field}" with value "{value}"')
 def step_impl(context,id,field,value):

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -217,15 +217,17 @@ def step_impl(context, value):
     assert context.response_text.rfind(value) != -1
 
 
-@then('the results should include a node with ID "{node_id}"')
-def step_impl(context, node_id):
+@then('the results should include node "{node}"')
+def step_impl(context, node):
+    node_id = node.partition("(")[0].strip()  # Extract node ID from what was passed in
     nodes = context.response_json["knowledge_graph"]["nodes"]
     node_found = any(node['id'] == node_id for node in nodes)
     assert node_found
 
 
-@then('the results should include node "{node_id}" with similarity value > {min_expected_value}')
-def step_impl(context, node_id, min_expected_value):
+@then('the results should include node "{node}" with similarity value > {min_expected_value}')
+def step_impl(context, node, min_expected_value):
+    node_id = node.partition("(")[0].strip()  # Extract node ID from what was passed in
     results = context.response_json["results"]
     relevant_result = next((result for result in results if result['row_data'][3] == node_id), None)
     assert relevant_result is not None
@@ -250,9 +252,11 @@ def step_impl(context, source_node, target_node, edge_type):
     """
     This step checks for the presence of a particular edge in the response knowledge graph.
     """
+    source_node_id = source_node.partition("(")[0].strip()  # Extract node ID from what was passed in
+    target_node_id = target_node.partition("(")[0].strip()  # Extract node ID from what was passed in
     edges = context.response_json["knowledge_graph"]["edges"]
-    edge_found = any(edge['source_id'] == source_node
-                     and edge['target_id'] == target_node
+    edge_found = any(edge['source_id'] == source_node_id
+                     and edge['target_id'] == target_node_id
                      and edge['type'] == edge_type for edge in edges)
     assert edge_found
 


### PR DESCRIPTION
- Added a few more simple structural test cases for RTX (malaria/sickle cell, PKU/PAH, etc...)
- Added a step that compares a result's similarity value to a minimum expected value
- Added an RTX test case that utilizes this similarity value step (naproxen/COX pathway)
- Made RTX step parameters allow node names in parens for readability in the .feature file (names are ignored in the step code)