### PR TITLE
README clarifications, gitignores and Tranql server port tweak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ my-working-environment/
 *.pyc
 /venv/
 /reasoner_diff/*
+**/__pycache__

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 my-working-environment/
 .idea
 *.pyc
+/venv/
+/reasoner_diff/

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ my-working-environment/
 .idea
 *.pyc
 /venv/
-/reasoner_diff/
+/reasoner_diff/*

--- a/README.md
+++ b/README.md
@@ -26,6 +26,34 @@ Now install required packages,
 pip install -r requirements.txt
 ```
 
+## Running Local support services for the Behave tests
+
+The behave tests rely on access to additional REST microservices running locally. These need to be started first, 
+before running the tests.
+
+### Translator Reasoner Graph comparison service
+
+Run the  `reasoner_diff/server.py`:
+ 
+```
+cd reasoner_diff
+python server.py
+```
+
+which starts a local server on `http://0.0.0.0:9999` for Translator reasoner graph comparisons.
+
+### TRANQL Server
+
+The Translator Testing Framework now incorporates [TranQL](https://github.com/NCATS-Tangerine/tranql) queries.
+
+TranQL is a query language for interactive exploration of federated knowledge graphs. Its queries may span multiple 
+reasoners, namely, ICEES, Gamma, RTX, and (partially) Indigo.
+
+To run the TranQL tests, you must run the TranQL dev server. You need to use 
+[this fork](https://github.com/frostyfan109/tranql/).
+
+To run the dev server, follow the installation and usage guide in the repository's README file. 
+You only need to run the backplane and API.
 
 ## Running Behave tests
 
@@ -34,16 +62,14 @@ To run the Behave tests,
 behave
 ```
 
-> To successfully run all the defined tests, be sure to run the `reasoner_diff/server.py` first.
-> `reasoner_diff/server.py` will start a local server on `http://0.0.0.0:9999`.
-
 Run a single feature file
 
 ```shell
 behave -i features/check-reasoners.feature
 ```
 
-
+To only run TranQL specific tests, run 
+`behave features/tranql-invalid-schema.feature features/tranql-reasoners.feature` in the root directory.
 
 ## Run with Docker
 
@@ -112,14 +138,3 @@ Objectives
 - Allow for strict as well as fuzzy validation
 - Easy for Subject Matter Experts (SMEs) to write tests
 - Easy for programmers to codify testing behavior
-
-## Fork purpose
-
-The purpose of this fork is to extend the Translator Testing Framework's capabilities to incorporate [TranQL](https://github.com/NCATS-Tangerine/tranql) queries.
-
-TranQL is a query language for interactive exploration of federated knowledge graphs. Its queries may span multiple reasoners, namely, ICEES, Gamma, RTX, and (partially) Indigo.
-
-To only run TranQL specific tests, run `behave features/tranql-invalid-schema.feature features/tranql-reasoners.feature` in the root directory.
-
-To run the TranQL tests, you must run the TranQL dev server. You need to use [this fork](https://github.com/frostyfan109/tranql/).
-To run the dev server, follow the installation and usage guide in the repository's readme file. You only need to run the backplane and API.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,10 @@ git clone --recursive https://github.com/deepakunni3/translator-testing-framewor
 
 **Note:** Be sure to use `--recursive` flag to clone the [NCATS-Tangerine/NCATS-ReasonerStdAPI-diff](https://github.com/NCATS-Tangerine/NCATS-ReasonerStdAPI-diff) dependency.
 
-After cloning the repo, set up a virtual environment using Python 3's `venv` module,
+
+After cloning the repo, set up a virtual environment using Python 3's `venv` module (or your preferred tool, e.g. 
+Conda or local IDE equivalent),
+
 ```
 python3 -m venv my-working-environment
 ```
@@ -28,7 +31,7 @@ pip install -r requirements.txt
 
 ## Running Local support services for the Behave tests
 
-The behave tests rely on access to additional REST microservices running locally. These need to be started first, 
+Some Behave tests rely on access to additional REST microservices running locally. These need to be started first, 
 before running the tests.
 
 ### Translator Reasoner Graph comparison service

--- a/features/environment.py
+++ b/features/environment.py
@@ -4,7 +4,7 @@ def before_all(context):
     context.target = 'http://127.0.0.1:9999'
 
     tranql_conf = {
-        'dev' : "http://localhost:8001/tranql/query",
+        'dev' : "http://localhost:8099/tranql/query",  # the suggested 'dev' server seems to publish on port 8099?
         'prod' : "https://tranql.renci.org/tranql/query"
     };
     environment = os.getenv('ENV', "dev")

--- a/features/knowledge-beacon-tests.feature
+++ b/features/knowledge-beacon-tests.feature
@@ -1,0 +1,142 @@
+Feature: Check knowledge beacons
+
+    Scenario: Check Rhea Beacon categories
+        Given a knowledge source at "https://kba.ncats.io/beacon/rhea"
+        when we fire "/categories" query
+        then the response contains the following entries in "category":
+            | category                   |
+            | chemical substance         |
+            | protein                    |
+            | molecular activity         |
+        and the response only contains the following entries in "category":
+            | category                   |
+            | chemical substance         |
+            | protein                    |
+            | molecular activity         |
+
+    Scenario: Check Rhea Beacon predicates
+        Given a knowledge source at "https://kba.ncats.io/beacon/rhea"
+        when we fire "/predicates" query
+        then the response contains the following entries in "relation":
+            | relation                                                     |
+            | participates in the same reaction side as                    |
+            | participates in the opposite reaction side as                |
+            | probably increases synthesis (might increase degradation) of |
+            | probably increases degradation (might increase synthesis) of |
+            | participates_in                                              |
+            | increases_activity_of                                        |
+            | catalyzes same reaction as                                   |
+            | has same catalyst                                            |
+        and the response only contains the following entries in "relation":
+            | relation                                                     |
+            | participates in the same reaction side as                    |
+            | participates in the opposite reaction side as                |
+            | probably increases synthesis (might increase degradation) of |
+            | probably increases degradation (might increase synthesis) of |
+            | participates_in                                              |
+            | increases_activity_of                                        |
+            | catalyzes same reaction as                                   |
+            | has same catalyst                                            |
+        and the response contains the following entries in "edge_label":
+            | edge_label                 |
+            | molecularly_interacts_with |
+            | derives_into               |
+            | increases_synthesis_of     |
+            | increases_degradation_of   |
+            | participates_in            |
+            | increases_activity_of      |
+            | related_to                 |
+        and the response only contains the following entries in "edge_label":
+            | edge_label                 |
+            | molecularly_interacts_with |
+            | derives_into               |
+            | increases_synthesis_of     |
+            | increases_degradation_of   |
+            | participates_in            |
+            | increases_activity_of      |
+            | related_to                 |
+
+    Scenario: Check Rhea Beacon Knowledge Map
+        Given a knowledge source at "https://kba.ncats.io/beacon/rhea"
+        when we fire "/kmap" query
+        then the response contains the following entries in "category" of "subject":
+            | category                   |
+            | chemical substance         |
+            | protein                    |
+            | molecular activity         |
+        and the response only contains the following entries in "category" of "subject":
+            | category                   |
+            | chemical substance         |
+            | protein                    |
+            | molecular activity         |
+        and the response contains the following entries in "relation" of "predicate":
+            | relation                                                     |
+            | participates in the same reaction side as                    |
+            | participates in the opposite reaction side as                |
+            | probably increases synthesis (might increase degradation) of |
+            | probably increases degradation (might increase synthesis) of |
+            | participates_in                                              |
+            | increases_activity_of                                        |
+            | catalyzes same reaction as                                   |
+            | has same catalyst                                            |
+        and the response only contains the following entries in "relation" of "predicate":
+            | relation                                                     |
+            | participates in the same reaction side as                    |
+            | participates in the opposite reaction side as                |
+            | probably increases synthesis (might increase degradation) of |
+            | probably increases degradation (might increase synthesis) of |
+            | participates_in                                              |
+            | increases_activity_of                                        |
+            | catalyzes same reaction as                                   |
+            | has same catalyst                                            |
+        and the response contains the following entries in "category" of "object":
+            | category                   |
+            | chemical substance         |
+            | protein                    |
+            | molecular activity         |
+        and the response only contains the following entries in "category" of "object":
+            | category                   |
+            | chemical substance         |
+            | protein                    |
+            | molecular activity         |
+
+    Scenario: Check Rhea Beacon concepts
+        Given a knowledge source at "https://kba.ncats.io/beacon/rhea"
+        when we fire "/concepts?keywords=aspirin&categories=protein" query
+        then the response contains "Acetylsalicylate deacetylase." in "name"
+
+    Scenario: Check Rhea Beacon exactmatches
+        Given a knowledge source at "https://kba.ncats.io/beacon/rhea"
+        when we fire "/exactmatches?c=EC%3A3.1.1.55" query
+        then the size of the response is 1
+        and the response should have some JSONPath "$[0].has_exact_matches[0]" with "string" ""
+
+    Scenario: Check Rhea Beacon concept
+        Given a knowledge source at "https://kba.ncats.io/beacon/rhea"
+        when we fire "/concepts/EC%3A3.1.1.55" query
+        then the response should have some JSONPath "id" with "string" "EC:3.1.1.55"
+        then the response should have some JSONPath "name" with "string" "Acetylsalicylate deacetylase."
+        then the response should have some JSONPath "uri" with "string" "https://enzyme.expasy.org/EC/3.1.1.55"
+
+    Scenario: Check Rhea Beacon statements
+        Given a knowledge source at "https://kba.ncats.io/beacon/rhea"
+        when we fire "/statements?s=EC%3A3.1.1.55" query
+        then the response only contains the following entries in "id" of "subject":
+            | id          |
+            | EC:3.1.1.55 |
+        and the response only contains the following entries in "name" of "subject":
+            | name                         |
+            | Acetylsalicylate deacetylase.|
+        and the response only contains the following entries in "edge_label" of "predicate":
+            | edge_label               |
+            | increases_synthesis_of   |
+            | increases_degradation_of |
+            | increases_activity_of    |
+        and the response only contains the following entries in "id" of "object":
+            | id          |
+            | CHEBI:30762 |
+            | CHEBI:15378 |
+            | CHEBI:30089 |
+            | CHEBI:15377 |
+            | CHEBI:13719 |
+            | RHEA:11752  |

--- a/features/knowledge-beacon-tests.feature
+++ b/features/knowledge-beacon-tests.feature
@@ -105,11 +105,12 @@ Feature: Check knowledge beacons
         when we fire "/concepts?keywords=aspirin&categories=protein" query
         then the response contains "Acetylsalicylate deacetylase." in "name"
 
-    Scenario: Check Rhea Beacon exactmatches
-        Given a knowledge source at "https://kba.ncats.io/beacon/rhea"
-        when we fire "/exactmatches?c=EC%3A3.1.1.55" query
-        then the size of the response is 1
-        and the response should have some JSONPath "$[0].has_exact_matches[0]" with "string" ""
+    # Rhea doesn't really support exactmatches?
+    #Scenario: Check Rhea Beacon exactmatches
+    #    Given a knowledge source at "https://kba.ncats.io/beacon/rhea"
+    #    when we fire "/exactmatches?c=EC%3A3.1.1.55" query
+    #    then the size of the response is 1
+    #    and the response should have some JSONPath "$[0].has_exact_matches[0]" with "string" ""
 
     Scenario: Check Rhea Beacon concept
         Given a knowledge source at "https://kba.ncats.io/beacon/rhea"


### PR DESCRIPTION
* I attempted to clarify the project README to assist deployment by users unfamiliar with the project. 

* The Tranql default port was 8001 whereas the suggested 'dev' fork of Tranql deploys its local 'dev' backplane server on port 8099. 

* Some useful .gitignore was added(?)

* Added a fresh Behave *feature* test for the Rhea Knowledge Beacon, reusing Vlado Dancik's 'knowledge-source.feature' which tests the HMDB knowledge beacon.