### PR TITLE
Create medikanren-tests.feature

### DIFF
--- a/features/medikanren-tests.feature
+++ b/features/medikanren-tests.feature
@@ -18,3 +18,20 @@ Feature: Check mediKanren responses
         When the message is processed by http://localhost:8000/query
         Then we expect a HTTP "200"
         And the response should have some result that binds node n02 to UMLS:C1823619
+
+    Scenario: Nausea Query finds Isopropyl Alcohol
+        Given query_graph
+        """
+        {
+            "nodes": [
+                {"id": "n01", "type": "chemical_substance"},
+                {"id": "n02", "curie": "UMLS:C0027497"}
+            ],
+            "edges": [
+                {"id": "e12", "type": "treats",           "source_id": "n01", "target_id": "n02"}
+            ]
+        }
+        """
+        When the message is processed by http://localhost:8000/query
+        Then we expect a HTTP "200"
+        And the response should have some result that binds node n01 to UMLS:C0022237

--- a/features/medikanren-tests.feature
+++ b/features/medikanren-tests.feature
@@ -1,0 +1,20 @@
+Feature: Check mediKanren responses
+
+    Scenario: Imatinib Asthma Query finds VEGFA Gene
+        Given query_graph
+        """
+        {
+            "nodes": [
+                {"id": "n01", "curie": "UMLS:C0935989"},
+                {"id": "n02", "type": "gene"},
+                {"id": "n03", "curie": "UMLS:C0004096"}
+            ],
+            "edges": [
+                {"id": "e12", "type": "negatively_regulates",           "source_id": "n01", "target_id": "n02"},
+                {"id": "e23", "type": "gene_associated_with_condition", "source_id": "n02", "target_id": "n03"}
+            ]
+        }
+        """
+        When the message is processed by http://localhost:8000/query
+        Then we expect a HTTP "200"
+        And the response should have some result that binds node n02 to UMLS:C1823619

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -130,6 +130,11 @@ def step_impl(context):
     }
 
 
+@given('query_graph')
+def step_impl(context):
+    context.query_graph = json.loads(context.text)
+
+
 """
 When
 """
@@ -480,6 +485,29 @@ def step_impl(context, json_path, data_type, value):
             is_found = True
 
     assert is_found is True
+
+
+@then('the response should have some result that binds node {qg_id} to {kg_id}')
+def step_impl(context, qg_id, kg_id):
+    found = False
+    for result in context.response_json['results']:
+        for nb in result['node_bindings']:
+            if nb['qg_id'] == qg_id and nb['kg_id'] == kg_id:
+                found = True
+                break
+    assert found == True
+
+
+@then('the response should have some result that binds edge {qg_id} to {kg_id}')
+def step_impl(context, qg_id, kg_id):
+    found = False
+    for result in context.response_json['results']:
+        for nb in result['edge_bindings']:
+            if nb['qg_id'] == qg_id and nb['kg_id'] == kg_id:
+                found = True
+                break
+    assert found == True
+
 
 @when('the message is processed by {url}')
 def call(context, url):


### PR DESCRIPTION
Steps are implemented for conveniently making assertions about `node_bindings` and `edge_bindings`.  The existing step implementations didn't make this easy.

Other reasoners have features which use the step "Given query_graph", which we'd like to use too.  Strangely, there doesn't seem to be an implementation, so I added one.

The feature file provides one example test case.  More will follow.